### PR TITLE
Generate a few more items automatically

### DIFF
--- a/core_weekly/core_weekly.py
+++ b/core_weekly/core_weekly.py
@@ -23,6 +23,9 @@ class CoreWeekly():
         self.year = None
         self.month = None
         self.week = None
+        self.first_day_number = None
+        self.last_day_number = None
+
         self.date_range = args.date
         if args.week is not None:
             self.date_range = self.get_date_range_from_week(args.week, args.year)
@@ -35,16 +38,6 @@ class CoreWeekly():
 
         self.is_debug = args.debug
         self.directory = Path(__file__).resolve().parents[1] / 'var'
-
-    def initialize_time_parameters(self, date_range):
-
-        split = date_range.split('..')
-        first_date = datetime.datetime.strptime(split[0], "%Y-%m-%d").date()
-
-        self.year = first_date.strftime('%Y')
-        self.month = first_date.strftime('%B')
-        self.week = first_date.strftime('%W')
-
 
     def get_date_range_from_week(self, week, year):
         """Get data range from week number
@@ -65,9 +58,34 @@ class CoreWeekly():
         first_day = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date()
         last_day = first_day + datetime.timedelta(days=6.9)
 
+        self.first_day_number = first_day.strftime('%d')
+        self.last_day_number = last_day.strftime('%d')
+
         self.month = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date().strftime('%B')
 
         return str(first_day) + '..' + str(last_day)
+
+
+    def initialize_time_parameters(self, date_range):
+
+        split = date_range.split('..')
+        first_date = datetime.datetime.strptime(split[0], "%Y-%m-%d").date()
+        last_date = datetime.datetime.strptime(split[1], "%Y-%m-%d").date()
+
+        if self.first_day_number is None:
+            self.first_day_number = first_date.strftime('%-d')
+        if self.last_day_number is None:
+            self.last_day_number = last_date.strftime('%-d')
+
+        if self.year is None:
+            self.year = first_date.strftime('%Y')
+        
+        if self.month is None:
+            self.month = last_date.strftime('%B')
+
+        if self.week is None:
+            self.week = (last_date++ datetime.timedelta(days=6.9)).strftime('%W')
+
 
     def generate(self):
         """Generate Core weekly markdown content
@@ -83,7 +101,7 @@ class CoreWeekly():
         opened_pull_requests = self.report.get_opened_pull_requests()
         closed_pull_requests = self.report.get_closed_pull_requests()
 
-        content = self.template.headers(self.week, self.month,self.year)
+        content = self.template.headers(self.first_day_number, self.last_day_number, self.week, self.month,self.year)
 
         if self.is_debug:
             content += self.template.opened_issues(opened_issues)

--- a/core_weekly/core_weekly.py
+++ b/core_weekly/core_weekly.py
@@ -21,18 +21,30 @@ class CoreWeekly():
 
         """
         self.year = None
+        self.month = None
         self.week = None
         self.date_range = args.date
         if args.week is not None:
             self.date_range = self.get_date_range_from_week(args.week, args.year)
 
         if self.date_range:
+            self.initialize_time_parameters(self.date_range)
             self.report = Report(self.date_range, args.no_cache, args.debug)
             self.parser = Parser()
             self.template = Template(self.parser)
 
         self.is_debug = args.debug
         self.directory = Path(__file__).resolve().parents[1] / 'var'
+
+    def initialize_time_parameters(self, date_range):
+
+        split = date_range.split('..')
+        first_date = datetime.datetime.strptime(split[0], "%Y-%m-%d").date()
+
+        self.year = first_date.strftime('%Y')
+        self.month = first_date.strftime('%B')
+        self.week = first_date.strftime('%W')
+
 
     def get_date_range_from_week(self, week, year):
         """Get data range from week number
@@ -53,6 +65,8 @@ class CoreWeekly():
         first_day = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date()
         last_day = first_day + datetime.timedelta(days=6.9)
 
+        self.month = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date().strftime('%B')
+
         return str(first_day) + '..' + str(last_day)
 
     def generate(self):
@@ -69,7 +83,7 @@ class CoreWeekly():
         opened_pull_requests = self.report.get_opened_pull_requests()
         closed_pull_requests = self.report.get_closed_pull_requests()
 
-        content = self.template.headers()
+        content = self.template.headers(self.week, self.month,self.year)
 
         if self.is_debug:
             content += self.template.opened_issues(opened_issues)

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -15,7 +15,7 @@ class Template():
         """
         self.parser = parser
 
-    def headers(self, week, month, year):
+    def headers(self, first_day_number, last_day_number, week, month, year):
         """Default header
 
         :returns: Original headers
@@ -55,9 +55,21 @@ This edition of the Core Weekly report highlights changes in PrestaShop\'s core 
         result = result.replace("YYYY", str(year))
         result = result.replace("MMMM", month)
 
-
+        result = result.replace("AA", self.format_day_number(first_day_number))
+        result = result.replace("ZZ", self.format_day_number(last_day_number))
 
         return result
+
+    def format_day_number(self, day_number):
+
+        if (day_number == '1'):
+            return '1st'
+        elif (day_number == '2'):
+            return '2nd'
+        elif (day_number == '3'):
+            return '3rd'
+        else:
+            return day_number + 'th'
 
     def footers(self):
         """Default footer

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -61,15 +61,12 @@ This edition of the Core Weekly report highlights changes in PrestaShop\'s core 
 
     def format_day_number(self, day_number):
 
-        if (day_number == '1'):
-            return '1st'
-        elif (day_number == '2'):
-            return '2nd'
-        elif (day_number == '3'):
-            return '3rd'
-        else:
-            return day_number + 'th'
-
+        day_numbers = {
+          1: '1st',
+          2: '2nd',
+          3: '3rd',
+        }
+        return day_numbers.get(day_number, day_number + 'th')
     def footers(self):
         """Default footer
 

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -4,7 +4,7 @@ from coreteam import CORE_BRANCHES
 from coreteam import CORE_TEAM
 from coreteam import CATEGORIES
 from collections import OrderedDict
-
+from datetime import date
 
 class Template():
     def __init__(self, parser):
@@ -15,26 +15,30 @@ class Template():
         """
         self.parser = parser
 
-    def headers(self):
+    def headers(self, week, month, year):
         """Default header
 
         :returns: Original headers
         :rtype: str
 
         """
-        return '''---
+
+        today = str(date.today())
+
+        template = '''---
 layout: post
-title:  "PrestaShop Core Weekly - Week XXXX of 2020"
+title:  "PrestaShop Core Weekly - Week WWWW of YYYY"
 subtitle: "An inside look at the PrestaShop codebase"
-date:   XXXX
+date:   DDDD
 authors: [ PrestaShop ]
 image: /assets/images/2017/04/core_weekly_banner.jpg
+twitter_image: /assets/images/theme/banner-core-weekly.jpg
 icon: icon-calendar
 tags:
  - core-weekly
 ---
 
-This edition of the Core Weekly report highlights changes in PrestaShop\'s core codebase from Monday XX to Sunday XX of MONTH XXXX.
+This edition of the Core Weekly report highlights changes in PrestaShop\'s core codebase from Monday AA to Sunday ZZ of MMMM YYYY.
 
 ![Core Weekly banner](/assets/images/2018/12/banner-core-weekly.jpg)
 
@@ -45,6 +49,15 @@ This edition of the Core Weekly report highlights changes in PrestaShop\'s core 
 
 ## A quick update about PrestaShop\'s GitHub issues and pull requests:
 '''
+
+        result = template.replace("DDDD", today)
+        result = result.replace("WWWW", str(week))
+        result = result.replace("YYYY", str(year))
+        result = result.replace("MMMM", month)
+
+
+
+        return result
 
     def footers(self):
         """Default footer

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -27,9 +27,9 @@ class Template():
 
         template = '''---
 layout: post
-title:  "PrestaShop Core Weekly - Week WWWW of YYYY"
+title:  "PrestaShop Core Weekly - Week {week} of {year}"
 subtitle: "An inside look at the PrestaShop codebase"
-date:   DDDD
+date:   {today}
 authors: [ PrestaShop ]
 image: /assets/images/2017/04/core_weekly_banner.jpg
 twitter_image: /assets/images/theme/banner-core-weekly.jpg
@@ -38,7 +38,7 @@ tags:
  - core-weekly
 ---
 
-This edition of the Core Weekly report highlights changes in PrestaShop\'s core codebase from Monday AA to Sunday ZZ of MMMM YYYY.
+This edition of the Core Weekly report highlights changes in PrestaShop\'s core codebase from Monday {first_day} to Sunday {last_day} of {month} {year}.
 
 ![Core Weekly banner](/assets/images/2018/12/banner-core-weekly.jpg)
 
@@ -50,15 +50,14 @@ This edition of the Core Weekly report highlights changes in PrestaShop\'s core 
 ## A quick update about PrestaShop\'s GitHub issues and pull requests:
 '''
 
-        result = template.replace("DDDD", today)
-        result = result.replace("WWWW", str(week))
-        result = result.replace("YYYY", str(year))
-        result = result.replace("MMMM", month)
-
-        result = result.replace("AA", self.format_day_number(first_day_number))
-        result = result.replace("ZZ", self.format_day_number(last_day_number))
-
-        return result
+        return template.format(
+            today=today,
+            week=str(week),
+            month=month,
+            year=str(year),
+            first_day=self.format_day_number(first_day_number),
+            last_day=self.format_day_number(last_day_number)
+        )
 
     def format_day_number(self, day_number):
 


### PR DESCRIPTION
With these changes, I can generate a Core Weekly with the following items already complete:

```
---
layout: post
title:  "PrestaShop Core Weekly - Week 31 of 2019"
subtitle: "An inside look at the PrestaShop codebase"
date:   2020-07-17
authors: [ PrestaShop ]
image: /assets/images/2017/04/core_weekly_banner.jpg
twitter_image: /assets/images/theme/banner-core-weekly.jpg
icon: icon-calendar
tags:
 - core-weekly
---

This edition of the Core Weekly report highlights changes in PrestaShop's core codebase from Monday Ast to Sunday 7th of August 2019.
```

In comparison to previously:
```
---
layout: post
title:  "PrestaShop Core Weekly - Week XX of YYYY"
subtitle: "An inside look at the PrestaShop codebase"
date:   XXXX
authors: [ PrestaShop ]
image: /assets/images/2017/04/core_weekly_banner.jpg
twitter_image: /assets/images/theme/banner-core-weekly.jpg
icon: icon-calendar
tags:
 - core-weekly
---

This edition of the Core Weekly report highlights changes in PrestaShop's core codebase from Monday XX to Sunday XX of MONTH XXXX.
```

It works if you provide a week number or if you provide a date range.