### PR TITLE
Dont use zero-padded decimal for day number when using week number input

### DIFF
--- a/core_weekly/core_weekly.py
+++ b/core_weekly/core_weekly.py
@@ -58,8 +58,8 @@ class CoreWeekly():
         first_day = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date()
         last_day = first_day + datetime.timedelta(days=6.9)
 
-        self.first_day_number = first_day.strftime('%d')
-        self.last_day_number = last_day.strftime('%d')
+        self.first_day_number = first_day.strftime('%-d')
+        self.last_day_number = last_day.strftime('%-d')
 
         self.month = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date().strftime('%B')
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Dont use zero-padded decimal for day number when using week number input
| Type?         | bug fix
| Fixed ticket? | Fixes https://github.com/PrestaShop/core-weekly-generator/issues/49


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
