### PR TITLE
[WIP] Introduce ability to fetch releases thanks to PyGithub

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Display help
 
 ```bash
 $ ./core-weekly.py --help
-usage: core-weekly.py [-h] [--no-cache] [--debug] [--stats] [--year YEAR]
+usage: core-weekly.py [-h] [--no-cache] [--debug] [--stats] [--year YEAR] --token=GITHUB_ACCESS_TOKEN
                       (--date DATE | --week WEEK | --compute)
 
 PrestaShop Core Weekly

--- a/core-weekly.py
+++ b/core-weekly.py
@@ -11,7 +11,8 @@ def main():
     parser.add_argument('--no-cache', action='store_const', const=True, help='Disable cache')
     parser.add_argument('--debug', action='store_const', const=True, help='Use Debug')
     parser.add_argument('--stats', action='store_const', const=True, help='Print stats report and save it in json file if you specify a week number')
-    parser.add_argument('--year', type=str, help='Specifcy which year you want to use in Week context')
+    parser.add_argument('--year', type=str, help='Specify which year you want to use in Week context')
+    parser.add_argument('--token', type=str, help='GitHub Access Token', required=True)
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--date', type=str, help='Date range')

--- a/core_weekly/core_weekly.py
+++ b/core_weekly/core_weekly.py
@@ -4,6 +4,7 @@ from .report import Report
 from .template import Template
 from .parser import Parser
 from .date_util import DateUtil
+from .github import GitHubClient
 from pathlib import Path
 import datetime
 import json
@@ -31,7 +32,7 @@ class CoreWeekly():
 
         if self.date_range:
             self.initialize_time_parameters(self.date_range)
-            self.report = Report(self.date_range, args.no_cache, args.debug)
+            self.report = Report(self.date_range, args.no_cache, args.debug, args.token)
             self.parser = Parser()
             self.template = Template(self.parser)
 
@@ -65,12 +66,17 @@ class CoreWeekly():
         merged_pull_requests = self.report.get_merged_pull_requests()
         opened_pull_requests = self.report.get_opened_pull_requests()
         closed_pull_requests = self.report.get_closed_pull_requests()
+        last_week_releases = self.report.get_last_week_releases()
 
         content = self.template.headers(
             DateUtil().compute_from_day_to_day_statement(self.date_range),
             self.week,
             self.year
         )
+
+        content += self.template.last_week_releases(last_week_releases)
+
+        content += self.template.weekly_stats_statement()
 
         if self.is_debug:
             content += self.template.opened_issues(opened_issues)

--- a/core_weekly/github.py
+++ b/core_weekly/github.py
@@ -1,36 +1,67 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from github import Github
+from github import UnknownObjectException
 import requests_cache
 import logging
 import requests
 import ssl
 import time
+from datetime import date, datetime, timedelta
 
 logger = logging.getLogger(__name__)
 ssl._create_default_https_context = ssl._create_unverified_context
 
 
-# Github api
+# Github API Client
 #
-class GitHub():
+class GitHubClient():
     retries = 0
 
-    def __init__(self, no_cache, debug):
+    def __init__(self, no_cache, debug, github_access_token):
         """Constructor
 
         :param no_cache: Disable cache
         :type no_cache: bool
         :param debug: Is debug mode enabled
         :type debug: bool
+        :param github_access_token: GitHub Access Token
+        :type github_access_token: str
 
         """
         self.sleep_time = 3
         self.url = 'https://api.github.com/search/issues?per_page=100'
         self.no_cache = no_cache
         self.is_debug = debug
+        self.github_access_token = github_access_token
 
         if not self.no_cache:
             requests_cache.install_cache('cache')
+
+    def get_last_week_git_releases(self):
+        """Get last week GitRelease objects (see https://pygithub.readthedocs.io/)
+
+        :returns: List of dictionaries <GitRelease, Repository>
+        :rtype: list
+
+        """
+        g = Github(self.github_access_token)
+
+        all_repositories = g.search_repositories(query="org:PrestaShop")
+        last_week_releases = []
+        one_week_ago_date = date.today() - timedelta(days=7)
+        one_week_ago_datetime = datetime.combine(one_week_ago_date, datetime.min.time())
+
+        for repo in all_repositories:
+            try:
+                release = repo.get_latest_release()
+                if release.published_at > one_week_ago_datetime:
+                    last_week_releases.append({'release':release,'repo':repo})
+
+            except UnknownObjectException:
+                pass
+
+        return last_week_releases      
 
     def build_query(self, query):
         """Build GitHub query
@@ -95,7 +126,7 @@ class GitHub():
 
             return self.execute(request_url)
         else:
-            GitHub.retries = 0
+            GitHubClient.retries = 0
             # Data not in cache, we must wait because of GitHub API rate limits
             if not hasattr(resp, 'from_cache') or not resp.from_cache:
                 time.sleep(self.sleep_time)

--- a/core_weekly/report.py
+++ b/core_weekly/report.py
@@ -1,10 +1,38 @@
-from .github import GitHub
+from .github import GitHubClient
 
 
 class Report:
-    def __init__(self, date_range, no_cache, debug):
-        self.github = GitHub(no_cache, debug)
+    def __init__(self, date_range, no_cache, debug, github_access_token):
+        self.github = GitHubClient(no_cache, debug, github_access_token)
         self.date_range = date_range
+
+    def format_release_item(self, release_data):
+        """Format a GitHub release list item string
+
+        :returns: Formatted string
+        :rtype: str
+
+        """
+        template = '- [{repository_name}]({repository_url}): [{version_title}]({version_url})'
+        repository = release_data['repo']
+        release = release_data['release']
+
+        return template.format(
+            repository_name=repository.name,
+            repository_url=repository.html_url,
+            version_title=release.title,
+            version_url=release.html_url
+        )
+
+    def get_last_week_releases(self):
+        """Get last week GitHub releases
+
+        :returns: List of last Week GitHub releases statements
+        :rtype: list
+
+        """
+        releases_data = self.github.get_last_week_git_releases()
+        return list(map(self.format_release_item, releases_data))
 
     def get_opened_issues(self):
         """Get opened issues

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -48,8 +48,6 @@ This edition of the Core Weekly report highlights changes in PrestaShop\'s core 
 
 [write a nice message here, or remove the "General messages" section]
 
-
-## A quick update about PrestaShop\'s GitHub issues and pull requests:
 '''
 
         return template.format(
@@ -58,6 +56,31 @@ This edition of the Core Weekly report highlights changes in PrestaShop\'s core 
             year=str(year),
             from_day_to_day_statement=from_day_to_day_statement
         )
+
+    def last_week_releases(self, releases):
+        """Releases block
+
+        :returns: Last week GitHub releases as a list of links
+        :rtype: str
+
+        """
+        template = '''## Releases
+
+{releases}
+
+'''
+
+        return template.format(releases='\n'.join(releases))
+
+    def weekly_stats_statement(self):
+        """Default Weekly Stats introduction sentence
+
+        :returns: sentence
+        :rtype: str
+
+        """
+        return '''## A quick update about PrestaShop\'s GitHub issues and pull requests:
+'''
 
     def footers(self):
         """Default footer


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  Introduce ability to fetch releases thanks to [PyGithub](https://github.com/PyGithub/PyGithub). However this means a GitHub access token is now required to run the Core Weekly as authenticated calls are required to fetch releases data. This addresses feature request https://github.com/PrestaShop/core-weekly-generator/issues/31
| Type?         | new feature
| BC breaks?    |  yes
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/core-weekly-generator/issues/31
| How to test?  | Run latest Core Weekly

## BC Breaks

Following the merge of this PR, a GitHub access token will be required to run the Core Weekly generator, contrarily to previous implementation.

## Status

Implementation is eligible for code review. I however need to
- add tests
- fix CI because I think it will fail since CI does not have a GitHub token