### PR TITLE
Handle years that start with different week numbers

### DIFF
--- a/core_weekly/core_weekly.py
+++ b/core_weekly/core_weekly.py
@@ -28,6 +28,7 @@ class CoreWeekly():
         self.date_range = args.date
         if args.week is not None:
             self.date_range = DateUtil().get_date_range_from_week(args.week, args.year)
+            self.week = args.week
 
         if self.date_range:
             self.initialize_time_parameters(self.date_range)

--- a/core_weekly/date_util.py
+++ b/core_weekly/date_util.py
@@ -33,7 +33,7 @@ class DateUtil():
         self.year = year
         self.week = week
 
-        first_day = datetime.datetime.strptime(f'{year}-W{int(week)-1}-1', "%Y-W%W-%w").date()
+        first_day = datetime.datetime.strptime(f'{year}-W{int(week)}-1', "%G-W%V-%u").date()
         last_day = first_day + datetime.timedelta(days=6.9)
 
         self.first_day_number = first_day.strftime('%-d')

--- a/tests/core_weekly/test_date_util.py
+++ b/tests/core_weekly/test_date_util.py
@@ -1,12 +1,13 @@
 import unittest
 from core_weekly.date_util import DateUtil
-import datetime
-import re
 
 
 class TestDateUtil(unittest.TestCase):
     def setUp(self):
         self.date_util = DateUtil()
+
+    def test_get_date_range_from_week_1_2020(self):
+        self.assertEqual(self.date_util.get_date_range_from_week(1, 2020), '2019-12-30..2020-01-05')
 
     def test_get_date_range_from_week_23_2020(self):
         self.assertEqual(self.date_util.get_date_range_from_week(23, 2020), '2020-06-01..2020-06-07')
@@ -14,9 +15,11 @@ class TestDateUtil(unittest.TestCase):
     def test_get_date_range_from_week_38_2020(self):
         self.assertEqual(self.date_util.get_date_range_from_week(38, 2020), '2020-09-14..2020-09-20')
 
-    def test_get_date_range_from_week_38(self):
-        now = datetime.datetime.now()
-        self.assertTrue(re.match(r'{}-04-0\d..{}-04-1\d'.format(now.year, now.year), self.date_util.get_date_range_from_week(15, None)))
+    def test_get_date_range_from_week_1_2021(self):
+        self.assertEqual(self.date_util.get_date_range_from_week(1, 2021), '2021-01-04..2021-01-10')
+
+    def test_get_date_range_from_week_28_2021(self):
+        self.assertEqual(self.date_util.get_date_range_from_week(28, 2021), '2021-07-12..2021-07-18')
 
     def test_format_day_number_2nd(self):
         self.assertEqual(self.date_util.format_day_number(2), '2nd')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix how week number is computed. Tests validate the behavior, and official week numbers can be looked at on https://github.com/PrestaShop/core-weekly-generator/issues/89 and https://www.calendar-365.com/2021-calendar.html
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/core-weekly-generator/issues/89
| How to test?      | CI should be green

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
