### PR TITLE
Raise an exception if one fetched PR branch is unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,21 @@ When stats are downloaded, you can compute them.
 
 Be aware that data fetched from GitHub is stored into a local sqlite cache file! This might create issues when submitting code changes to the tool logic.
 
-## Running tests
+## Code quality
 
 Install dependencies:
 
 ```bash
 $ ./setup.py install
 ```
+
+### Static analysis
+
+```bash
+$ ./setup.py flake8
+```
+
+### Running tests
 
 To run unit tests:
 

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -288,7 +288,7 @@ Happy contributin' everyone!
         :param grouped_data_by_branches: Data we want to verify
         :type grouped_data_by_branches: dict
         :param branches: Core known branches
-        :type branches: str
+        :type branches: dict
         """
         for key in grouped_data_by_branches:
             if key not in branches:

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -283,20 +283,16 @@ Happy contributin' everyone!
 
         return sorted_dict
 
-
     def verify_no_unknown_branch(self, grouped_data_by_branches, branches):
         """Verify there is no unknown branch
-
         :param grouped_data_by_branches: Data we want to verify
         :type grouped_data_by_branches: dict
         :param branches: Core known branches
         :type branches: str
         """
-        only_useful_keys = []
         for key in grouped_data_by_branches:
             if key not in branches:
-                raise Exception('Cannot find branch '+key+' in configured branches')
-
+                raise Exception('Cannot find branch ' + key + ' in configured branches')
 
     def build_merged_pull_requests(self, result):
         """Build merged pull requests

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -283,6 +283,21 @@ Happy contributin' everyone!
 
         return sorted_dict
 
+
+    def verify_no_unknown_branch(self, grouped_data_by_branches, branches):
+        """Verify there is no unknown branch
+
+        :param grouped_data_by_branches: Data we want to verify
+        :type grouped_data_by_branches: dict
+        :param branches: Core known branches
+        :type branches: str
+        """
+        only_useful_keys = []
+        for key in grouped_data_by_branches:
+            if key not in branches:
+                raise Exception('Cannot find branch '+key+' in configured branches')
+
+
     def build_merged_pull_requests(self, result):
         """Build merged pull requests
 
@@ -301,6 +316,7 @@ Happy contributin' everyone!
             return ''
 
         grouped_core_items = self.sort_core_repositories(core_items)
+        self.verify_no_unknown_branch(grouped_core_items, CORE_BRANCHES)
 
         sorted_core_items = self.custom_sort(grouped_core_items, CORE_BRANCHES)
 

--- a/core_weekly/template.py
+++ b/core_weekly/template.py
@@ -292,7 +292,7 @@ Happy contributin' everyone!
         """
         for key in grouped_data_by_branches:
             if key not in branches:
-                raise Exception('Cannot find branch ' + key + ' in configured branches')
+                raise Exception('Cannot find branch "{}" in configured branches'.format(key))
 
     def build_merged_pull_requests(self, result):
         """Build merged pull requests


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Raise an exception if one fetched PR branch is unknown
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #96
| How to test?      | See below

### How to test

Remove from CORE_BRANCHES dictionary the `1.7.8.x` item then run `python core-weekly.py --week=29`.

Expected output
```
Traceback (most recent call last):
  File "core-weekly.py", line 36, in <module>
    main()
  File "core-weekly.py", line 30, in main
    print(core_weekly.generate())
  File "/Users/mFerment/www/prestashop/core-weekly-generator/core_weekly/core_weekly.py", line 98, in generate
    content += self.template.build_merged_pull_requests(merged_pull_requests)
  File "/Users/mFerment/www/prestashop/core-weekly-generator/core_weekly/template.py", line 321, in build_merged_pull_requests
    self.verify_no_unknown_branch(grouped_core_items, CORE_BRANCHES)
  File "/Users/mFerment/www/prestashop/core-weekly-generator/core_weekly/template.py", line 300, in verify_no_unknown_branch
    raise Exception('Cannot find branch '+key+' in configured branches')
Exception: Cannot find branch 1.7.8.x in configured branches
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
